### PR TITLE
Glowsquito Targeting Fix

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/entities/GlowsquitoEntity.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/GlowsquitoEntity.java
@@ -120,7 +120,7 @@ public class GlowsquitoEntity extends AnimalEntity implements IFlyingAnimal {
 	@Override
 	protected void collideWithEntity(Entity entityIn) {
 		super.collideWithEntity(entityIn);
-		if (!this.isChild() && entityIn instanceof LivingEntity) {
+		if (!this.isChild() && entityIn instanceof LivingEntity && !(entityIn instanceof GlowsquitoEntity)) {
 			((LivingEntity) entityIn).addPotionEffect(new EffectInstance(IEEffects.LUMINOUS.get(), 200));
 		}
 	}
@@ -316,8 +316,8 @@ public class GlowsquitoEntity extends AnimalEntity implements IFlyingAnimal {
         //this.goalSelector.addGoal(7, new GlowsquitoEntity.LookAroundGoal(this));
         //this.goalSelector.addGoal(5, this.eatGrassGoal);
         this.targetSelector.addGoal(0, new HurtByTargetGoal(this));
-        this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, CreatureEntity.class, true, false, IEEffects.LUMINOUS.get()));
-        this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, MonsterEntity.class, true, false, IEEffects.LUMINOUS.get()));
+        this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, CreatureEntity.class, true, false, IEEffects.LUMINOUS.get(), GlowsquitoEntity.class));
+        this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, MonsterEntity.class, true, false, IEEffects.LUMINOUS.get(), GlowsquitoEntity.class));
         this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, BlackstoneDwarfEntity.class, true));
     }
 

--- a/src/main/java/com/nekomaster1000/infernalexp/entities/VolineEntity.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/VolineEntity.java
@@ -79,7 +79,7 @@ public class VolineEntity extends MonsterEntity {
         this.goalSelector.addGoal(0, new VolineEatItemsGoal(this, MiscEvents.getVolineEatTable(), 32.0D, getAttributeValue(Attributes.MOVEMENT_SPEED) * 2.0D));
         this.goalSelector.addGoal(1, new MeleeAttackGoal(this, getAttributeValue(Attributes.MOVEMENT_SPEED) * 1.2D, true));
 		this.targetSelector.addGoal(0, new HurtByTargetGoal(this));
-		this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, LivingEntity.class, true, false, Effects.FIRE_RESISTANCE));
+		this.targetSelector.addGoal(1, new TargetWithEffectGoal(this, LivingEntity.class, true, false, Effects.FIRE_RESISTANCE, null));
 		this.targetSelector.addGoal(2, new NearestAttackableTargetGoal<>(this, PlayerEntity.class, true));
 		this.goalSelector.addGoal(2, new WaterAvoidingRandomWalkingGoal(this, getAttributeValue(Attributes.MOVEMENT_SPEED)));
 		this.goalSelector.addGoal(2, new LookAtGoal(this, PlayerEntity.class, 8.0F));

--- a/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
@@ -18,7 +18,7 @@ public class TargetWithEffectGoal extends NearestAttackableTargetGoal {
     private final Effect effect;
     private final Class invalidTarget;
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, Effect effect, @Nullable  Class invalidTargetClassIn) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, Effect effect, @Nullable Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, checkSight);
         this.effect = effect;
         this.invalidTarget = invalidTargetClassIn;

--- a/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
@@ -30,7 +30,7 @@ public class TargetWithEffectGoal extends NearestAttackableTargetGoal {
 		this.invalidTarget = invalidTargetClassIn;
     }
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, int targetChanceIn, boolean checkSight, boolean nearbyOnlyIn, Predicate targetPredicate, Effect effect, @Nullable  Class invalidTargetClassIn) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, int targetChanceIn, boolean checkSight, boolean nearbyOnlyIn, Predicate targetPredicate, Effect effect, @Nullable Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, targetChanceIn, checkSight, nearbyOnlyIn, targetPredicate);
         this.effect = effect;
 		this.invalidTarget = invalidTargetClassIn;

--- a/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
@@ -24,7 +24,7 @@ public class TargetWithEffectGoal extends NearestAttackableTargetGoal {
         this.invalidTarget = invalidTargetClassIn;
     }
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, boolean nearbyOnlyIn, Effect effect, @Nullable  Class invalidTargetClassIn) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, boolean nearbyOnlyIn, Effect effect, @Nullable Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, checkSight, nearbyOnlyIn);
         this.effect = effect;
 		this.invalidTarget = invalidTargetClassIn;

--- a/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TargetWithEffectGoal.java
@@ -1,14 +1,13 @@
 package com.nekomaster1000.infernalexp.entities.ai;
 
-import java.util.function.Predicate;
-
-import javax.annotation.Nullable;
-
 import net.minecraft.entity.EntityPredicate;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.ai.goal.NearestAttackableTargetGoal;
 import net.minecraft.potion.Effect;
+
+import javax.annotation.Nullable;
+import java.util.function.Predicate;
 
 /**
  * This goal allows a Mob to target a Player who has a potion effect. The constructor is similar to the basic
@@ -17,24 +16,31 @@ import net.minecraft.potion.Effect;
  */
 public class TargetWithEffectGoal extends NearestAttackableTargetGoal {
     private final Effect effect;
+    private final Class invalidTarget;
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, Effect effect) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, Effect effect, @Nullable  Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, checkSight);
         this.effect = effect;
+        this.invalidTarget = invalidTargetClassIn;
     }
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, boolean nearbyOnlyIn, Effect effect) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, boolean checkSight, boolean nearbyOnlyIn, Effect effect, @Nullable  Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, checkSight, nearbyOnlyIn);
         this.effect = effect;
+		this.invalidTarget = invalidTargetClassIn;
     }
 
-    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, int targetChanceIn, boolean checkSight, boolean nearbyOnlyIn, Predicate targetPredicate, Effect effect) {
+    public TargetWithEffectGoal(MobEntity goalOwnerIn, Class targetClassIn, int targetChanceIn, boolean checkSight, boolean nearbyOnlyIn, Predicate targetPredicate, Effect effect, @Nullable  Class invalidTargetClassIn) {
         super(goalOwnerIn, targetClassIn, targetChanceIn, checkSight, nearbyOnlyIn, targetPredicate);
         this.effect = effect;
+		this.invalidTarget = invalidTargetClassIn;
     }
 
     @Override
     protected boolean isSuitableTarget(@Nullable LivingEntity potentialTarget, EntityPredicate targetPredicate) {
+    	if (this.invalidTarget != null && potentialTarget != null && potentialTarget.getClass() == this.invalidTarget) {
+    		return false;
+		}
         return super.isSuitableTarget(potentialTarget, targetPredicate) && potentialTarget.isPotionActive(this.effect);
     }
 


### PR DESCRIPTION
-Glowsquitos no longer give each other Luminous on Collision
-Glowsquitos no longer target each other when they have Luminous
-Changed Voline Goal constructor to match new TargetWithEffectGoal