### PR TITLE
Fix Mob Spawning Crash

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/events/MobEvents.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/events/MobEvents.java
@@ -228,7 +228,7 @@ public class MobEvents {
 
                 event.getSpawns().withSpawner(EntityClassification.CREATURE,
                     new MobSpawnInfo.Spawners(IEEntityTypes.WARPBEETLE.get(),
-                        MobSpawning.WARPBEETLE_WARPED.getSpawnrate(), 5, 1));
+                        MobSpawning.WARPBEETLE_WARPED.getSpawnrate(), 1, 5));
             }
 
 		} else if (event.getName().toString().equals("minecraft:basalt_deltas")) {


### PR DESCRIPTION
-Swapped min and max values for WarpBeetles to stop mob spawning crash from min being larger than max