### PR TITLE
Blockstate fix and Shroomlight Bonemealing

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/events/MiscEvents.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/events/MiscEvents.java
@@ -143,11 +143,21 @@ public class MiscEvents {
         World world = event.getWorld();
         BlockPos pos = event.getPos();
         if (block == Blocks.SHROOMLIGHT && FloraBehaviour.SHROOMLIGHT_GROWABLE.getBool()) {
-            pos = pos.down();
-            if (world.isAirBlock(pos)) {
-                event.setResult(Event.Result.ALLOW);
-                if (world.getRandom().nextDouble() < FloraBehaviour.SHROOMLIGHT_GROW_CHANCE.getDouble() && !world.isRemote()) {
-                    world.setBlockState(pos, IEBlocks.SHROOMLIGHT_FUNGUS.get().getDefaultState().with(HorizontalBushBlock.FACE, AttachFace.CEILING), 3);
+            if (event.getWorld().getBiome(pos).getRegistryName().getPath().equals("warped_forest")) {
+                pos = pos.up();
+                if (world.isAirBlock(pos)) {
+                    event.setResult(Event.Result.ALLOW);
+                    if (world.getRandom().nextDouble() < FloraBehaviour.SHROOMLIGHT_GROW_CHANCE.getDouble() && !world.isRemote()) {
+                        world.setBlockState(pos, IEBlocks.SHROOMLIGHT_FUNGUS.get().getDefaultState().with(HorizontalBushBlock.FACE, AttachFace.FLOOR), 3);
+                    }
+                }
+            } else {
+                pos = pos.down();
+                if (world.isAirBlock(pos)) {
+                    event.setResult(Event.Result.ALLOW);
+                    if (world.getRandom().nextDouble() < FloraBehaviour.SHROOMLIGHT_GROW_CHANCE.getDouble() && !world.isRemote()) {
+                        world.setBlockState(pos, IEBlocks.SHROOMLIGHT_FUNGUS.get().getDefaultState().with(HorizontalBushBlock.FACE, AttachFace.CEILING), 3);
+                    }
                 }
             }
         }

--- a/src/main/resources/assets/infernalexp/blockstates/soul_slate_brick_vertical_slab.json
+++ b/src/main/resources/assets/infernalexp/blockstates/soul_slate_brick_vertical_slab.json
@@ -4,6 +4,6 @@
     "type=south": { "model": "infernalexp:block/soul_slate_brick_vertical_slab", "y": 180, "uvlock": true },
     "type=east": { "model": "infernalexp:block/soul_slate_brick_vertical_slab", "y": 90, "uvlock": true },
     "type=west": { "model": "infernalexp:block/soul_slate_brick_vertical_slab", "y": 270, "uvlock": true },
-    "type=double": { "model": "minecraft:block/soul_slate_bricks" }
+    "type=double": { "model": "infernalexp:block/soul_slate_bricks" }
   }
 }


### PR DESCRIPTION
Fixed blockstae for "soul_slate_brick_vertical_slab", "type=double" was set to "minecraft:soul_slate_bricks" rather than "infernalexp:soul_slate_bricks".

Bonemealing "shroomlight" now takes biome into consideration, if bonemealed in a "warped_forest" it will check the block above it and place the "shroomlight_fungus" on top of the block, all other biomes will default to checking beneath the block and subsequently place the "shromlight_fungus" beneath the block.