### PR TITLE
optimized sinkhole, fixed sinkhole and ravine from making floating lava

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/world/gen/carvers/GlowstoneRavineCarver.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/world/gen/carvers/GlowstoneRavineCarver.java
@@ -8,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.mojang.serialization.Codec;
 import com.nekomaster1000.infernalexp.init.IEBlocks;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -15,6 +16,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraft.world.chunk.IChunk;
 import net.minecraft.world.gen.carver.CanyonWorldCarver;
 import net.minecraft.world.gen.feature.ProbabilityConfig;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 
 public class GlowstoneRavineCarver extends CanyonWorldCarver {
 
@@ -108,5 +110,32 @@ public class GlowstoneRavineCarver extends CanyonWorldCarver {
         }
 
         return 0;
+    }
+
+
+    /**
+     * Ripped from NetherCarver so that this ravine does not create floating lava in the nether.
+     */
+    protected boolean carveBlock(IChunk chunk, Function<BlockPos, Biome> p_230358_2_, BitSet carvingMask, Random rand, BlockPos.Mutable mutableBlockPos, BlockPos.Mutable p_230358_6_, BlockPos.Mutable p_230358_7_, int p_230358_8_, int p_230358_9_, int p_230358_10_, int posX, int posZ, int posX2, int posY, int posZ2, MutableBoolean isSurface) {
+        int maskIndex = posX2 | posZ2 << 4 | posY << 8;
+        if (carvingMask.get(maskIndex)) {
+            return false;
+        } else {
+            carvingMask.set(maskIndex);
+            mutableBlockPos.setPos(posX, posY, posZ);
+            if (this.isCarvable(chunk.getBlockState(mutableBlockPos))) {
+                BlockState blockstate;
+                if (posY <= 31) {
+                    blockstate = LAVA.getBlockState();
+                } else {
+                    blockstate = CAVE_AIR;
+                }
+
+                chunk.setBlockState(mutableBlockPos, blockstate, false);
+                return true;
+            } else {
+                return false;
+            }
+        }
     }
 }

--- a/src/main/java/com/nekomaster1000/infernalexp/world/gen/features/SinkHoleFeature.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/world/gen/features/SinkHoleFeature.java
@@ -91,8 +91,7 @@ public class SinkHoleFeature extends Feature<NoFeatureConfig> {
 
             if (mutableBlockPos.getY() < generator.getSeaLevel()) {
                 world.setBlockState(mutableBlockPos, Blocks.LAVA.getDefaultState(), 3);
-            }
-            else {
+            } else {
                 world.setBlockState(mutableBlockPos, Blocks.AIR.getDefaultState(), 3);
             }
         }

--- a/src/main/java/com/nekomaster1000/infernalexp/world/gen/features/SinkHoleFeature.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/world/gen/features/SinkHoleFeature.java
@@ -26,8 +26,7 @@ public class SinkHoleFeature extends Feature<NoFeatureConfig> {
         BlockPos.Mutable mutableBlockPos = new BlockPos.Mutable().setPos(pos);
         if (!world.isAirBlock(mutableBlockPos) || world.getBlockState(mutableBlockPos.move(Direction.DOWN)).getBlock() != IEBlocks.GLOWDUST_SAND.get()) {
             return false;
-        }
-        else {
+        } else {
             int radius = minRadius + random.nextInt(maxRadius - minRadius);
             int depth = 10 + random.nextInt(6);
 


### PR DESCRIPTION
The solution was to make them place lava if below sealevel. Should help clean up those carvers/feature

Also, try to use BlockPos.Mutable when iterating over a large amount of space as calling .add every time will create a new blockpos object. It can get excessive to the garbage collector if you create millions of blockpos for a feature