### PR TITLE
More recipe advancements and some recipe clash fixes.

### DIFF
--- a/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/glow_glass.json
+++ b/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/glow_glass.json
@@ -1,0 +1,32 @@
+{
+  "parent": "infernalexp:recipes/root",
+  "rewards": {
+    "recipes": [
+      "infernalexp:smelting/glow_glass"
+    ]
+  },
+  "criteria": {
+    "has_glowdust_sand": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "infernalexp:glowdust_sand"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "infernalexp:smelting/glow_glass"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_glowdust_sand",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/glow_glass_pane.json
+++ b/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/glow_glass_pane.json
@@ -1,0 +1,32 @@
+{
+  "parent": "infernalexp:recipes/root",
+  "rewards": {
+    "recipes": [
+      "infernalexp:crafting/crafting_shaped/glow_glass_pane"
+    ]
+  },
+  "criteria": {
+    "has_glow_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "infernalexp:glow_glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "infernalexp:crafting/crafting_shaped/glow_glass_pane"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_glow_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/quartz_glass.json
+++ b/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/quartz_glass.json
@@ -1,0 +1,43 @@
+{
+  "parent": "infernalexp:recipes/root",
+  "rewards": {
+    "recipes": [
+      "infernalexp:crafting/crafting_shaped/quartz_glass"
+    ]
+  },
+  "criteria": {
+    "has_quartz": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:quartz"
+          }
+        ]
+      }
+    },
+    "has_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "infernalexp:crafting/crafting_shaped/quartz_glass"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_quartz",
+      "has_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/quartz_glass_pane.json
+++ b/src/main/resources/data/infernalexp/advancements/recipes/building_blocks/quartz_glass_pane.json
@@ -1,0 +1,32 @@
+{
+  "parent": "infernalexp:recipes/root",
+  "rewards": {
+    "recipes": [
+      "infernalexp:crafting/crafting_shaped/quartz_glass_pane"
+    ]
+  },
+  "criteria": {
+    "has_quartz_glass": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "infernalexp:quartz_glass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "infernalexp:crafting/crafting_shaped/quartz_glass_pane"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_quartz_glass",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/infernalexp/recipes/crafting/crafting_shaped/basalt_bricks.json
+++ b/src/main/resources/data/infernalexp/recipes/crafting/crafting_shaped/basalt_bricks.json
@@ -9,7 +9,7 @@
   {
     "x":
     {
-      "item": "minecraft:basalt"
+      "item": "minecraft:polished_basalt"
     }
   },
   "result":

--- a/src/main/resources/data/infernalexp/recipes/stonecutting/basalt_bricks.json
+++ b/src/main/resources/data/infernalexp/recipes/stonecutting/basalt_bricks.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:stonecutting",
   "ingredient": {
-    "item": "minecraft:basalt"
+    "item": "minecraft:polished_basalt"
   },
   "result": "infernalexp:basalt_bricks",
   "count": 1


### PR DESCRIPTION
Added recipe advancements for:

- Quartz Glass
- Quartz Glass Pane
- Glowlight Glass
- Glowlight Glass Pane

Fixed recipes that were clashing with vanilla:

- Basalt Bricks (crafting & stonecutting), swapped to use "polished_basalt" rather than "basalt".