### PR TITLE
Blindsight Tweak and Glowdust Sandstone Removal Fix

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/entities/BlindsightEntity.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/BlindsightEntity.java
@@ -50,7 +50,8 @@ public class BlindsightEntity extends MonsterEntity {
             .createMutableAttribute(Attributes.MAX_HEALTH, 24.0D)
                 .createMutableAttribute(Attributes.ATTACK_DAMAGE, 2.0D)
                 .createMutableAttribute(Attributes.ATTACK_KNOCKBACK, 1.5D)
-                .createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.9D);
+                .createMutableAttribute(Attributes.MOVEMENT_SPEED, 0.9D)
+                .createMutableAttribute(Attributes.FOLLOW_RANGE, 6.0D);
     }
 
     //BEHAVIOUR
@@ -263,7 +264,7 @@ public class BlindsightEntity extends MonsterEntity {
          * method as well.
          */
         public boolean shouldExecute() {
-            return !this.blindsight.isPassenger();
+            return !this.blindsight.isPassenger() && this.blindsight.getAttackTarget() != null;
         }
 
         /**

--- a/src/main/resources/data/infernalexp/loot_tables/chests/desolate_bastion_outpost_chest.json
+++ b/src/main/resources/data/infernalexp/loot_tables/chests/desolate_bastion_outpost_chest.json
@@ -46,11 +46,6 @@
         },
         {
           "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_sandstone"
-        },
-        {
-          "type": "minecraft:item",
           "weight": 3,
           "name": "infernalexp:glowdust"
         },
@@ -59,12 +54,6 @@
           "weight": 5,
           "name": "infernalexp:glowdust_stone_brick_slab"
         },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "name": "infernalexp:cut_glowdust_sandstone_slab"
-        },
-
         {
           "type": "minecraft:item",
           "weight": 4,

--- a/src/main/resources/data/infernalexp/loot_tables/chests/glowstone_canyon_ruin_chest.json
+++ b/src/main/resources/data/infernalexp/loot_tables/chests/glowstone_canyon_ruin_chest.json
@@ -51,11 +51,6 @@
         },
         {
           "type": "minecraft:item",
-          "weight": 10,
-          "name": "infernalexp:glowdust_sandstone"
-        },
-        {
-          "type": "minecraft:item",
           "weight": 3,
           "name": "infernalexp:glowdust"
         },
@@ -64,12 +59,6 @@
           "weight": 5,
           "name": "infernalexp:glowdust_stone_brick_slab"
         },
-        {
-          "type": "minecraft:item",
-          "weight": 5,
-          "name": "infernalexp:cut_glowdust_sandstone_slab"
-        },
-
         {
           "type": "minecraft:item",
           "weight": 4,

--- a/src/main/resources/data/infernalexp/tags/blocks/glow_fire_base_blocks.json
+++ b/src/main/resources/data/infernalexp/tags/blocks/glow_fire_base_blocks.json
@@ -7,9 +7,6 @@
     "infernalexp:glowdust_stone_bricks",
     "infernalexp:glowdust_stone_brick_slab",
     "infernalexp:glowdust_stone_brick_stairs",
-    "infernalexp:trapped_glowdust_sand",
-    "infernalexp:glowdust_sandstone_slab",
-    "infernalexp:glowdust_sandstone_stairs",
-    "infernalexp:glowdust_sandstone_wall"
+    "infernalexp:trapped_glowdust_sand"
   ]
 }

--- a/src/main/resources/data/infernalexp/tags/items/glowstone_canyon_blocks.json
+++ b/src/main/resources/data/infernalexp/tags/items/glowstone_canyon_blocks.json
@@ -53,17 +53,6 @@
     "infernalexp:cracked_glowdust_stone_bricks",
     "infernalexp:chiseled_glowdust_stone_bricks",
 
-    "infernalexp:glowdust_sandstone",
-    "infernalexp:cut_glowdust_sandstone",
-    "infernalexp:chiseled_glowdust_sandstone",
-    "infernalexp:smooth_glowdust_sandstone",
-    "infernalexp:glowdust_sandstone_slab",
-    "infernalexp:glowdust_sandstone_stairs",
-    "infernalexp:cut_glowdust_sandstone_slab",
-
-    "infernalexp:smooth_glowdust_sandstone_slab",
-    "infernalexp:smooth_glowdust_sandstone_stairs",
-    "infernalexp:glowdust_sandstone_wall",
     "infernalexp:crumbling_blackstone",
 
     "infernalexp:dullthorns_block"


### PR DESCRIPTION
-Fixed Glowdust Sandstone remnants still in tags and loot tables breaking the game
-Reduced Blindsight Detection Range to 6 blocks
-Made Blindsights only move while targeting an entity