### PR TITLE
Glimmer Gravel Update

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/blocks/TrappedGlowSandBlock.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/blocks/TrappedGlowSandBlock.java
@@ -2,6 +2,7 @@ package com.nekomaster1000.infernalexp.blocks;
 
 import com.nekomaster1000.infernalexp.init.IEBlocks;
 import com.nekomaster1000.infernalexp.init.IEEntityTypes;
+import com.nekomaster1000.infernalexp.init.IEParticleTypes;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.FallingBlockEntity;
@@ -19,6 +20,7 @@ public class TrappedGlowSandBlock extends GlowSandBlock {
     }
 
     private static final int updateRadius = 4;
+    private int ticksToFall = 10;
 
     @Override
     public void tick(BlockState state, ServerWorld world, BlockPos pos, Random rand) { }
@@ -43,11 +45,19 @@ public class TrappedGlowSandBlock extends GlowSandBlock {
 
     public void startFalling(ServerWorld world, BlockPos pos) {
         if ((world.isAirBlock(pos.down()) || canFallThrough(world.getBlockState(pos.down())) && pos.getY() >= 0)) {
-			world.playSound(null, pos, SoundEvents.BLOCK_SAND_PLACE, SoundCategory.BLOCKS, 1.5F, world.rand.nextFloat() * 0.1F + 0.9F);
 
-			FallingBlockEntity fallingblockentity = new FallingBlockEntity(world, (double) pos.getX() + 0.5D, pos.getY(), (double) pos.getZ() + 0.5D, world.getBlockState(pos));
-			this.onStartFalling(fallingblockentity);
-			world.addEntity(fallingblockentity);
+            if (this.ticksToFall == 0) {
+                world.playSound(null, pos, SoundEvents.BLOCK_SAND_PLACE, SoundCategory.BLOCKS, 1.5F, world.rand.nextFloat() * 0.1F + 0.9F);
+
+                FallingBlockEntity fallingblockentity = new FallingBlockEntity(world, (double) pos.getX() + 0.5D, pos.getY(), (double) pos.getZ() + 0.5D, world.getBlockState(pos));
+                this.onStartFalling(fallingblockentity);
+                world.addEntity(fallingblockentity);
+
+                this.ticksToFall = 10;
+            } else {
+                world.spawnParticle(IEParticleTypes.GLOWSTONE_SPARKLE.get(), pos.getX(), pos.getY(), pos.getZ(), 1, 0.0, 1.0, 0.0, 0.0);
+                this.ticksToFall--;
+            }
 		}
     }
 }

--- a/src/main/java/com/nekomaster1000/infernalexp/init/IEBlocks.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/init/IEBlocks.java
@@ -126,7 +126,7 @@ public class IEBlocks {
 
     public static final RegistryObject<Block> GLOWDUST_SAND = registerBlockWithDefaultItem("glowdust_sand", () -> new GlowSandBlock(0xFFC267, AbstractBlock.Properties.create(Material.SNOW_BLOCK, MaterialColor.SAND).setRequiresTool().harvestTool(ToolType.SHOVEL).hardnessAndResistance(0.5F).sound(SoundType.SAND)));
     public static final RegistryObject<Block> GLOWDUST = registerBlockWithDefaultItem("glowdust", () -> new GlowdustBlock(AbstractBlock.Properties.create(Material.SNOW, MaterialColor.SAND).setRequiresTool().harvestTool(ToolType.SHOVEL).hardnessAndResistance(0.2f).sound(SoundType.SAND)));
-    public static final RegistryObject<Block> TRAPPED_GLOWDUST_SAND = registerBlockWithDefaultItem("trapped_glowdust_sand", () -> new TrappedGlowSandBlock(0xFFC267, getProperties(GLOWDUST.get()).hardnessAndResistance(0.2F).setLightLevel(value -> 5)));
+    public static final RegistryObject<Block> TRAPPED_GLOWDUST_SAND = registerBlockWithDefaultItem("trapped_glowdust_sand", () -> new TrappedGlowSandBlock(0xFFC267, getProperties(GLOWDUST_SAND.get()).hardnessAndResistance(0.2F).setLightLevel(value -> 5)));
 
     public static final RegistryObject<Block> GLOWDUST_STONE = registerBlockWithDefaultItem("glowdust_stone", () -> new Block(getProperties(Blocks.SANDSTONE)));
     public static final RegistryObject<Block> GLOWDUST_STONE_SLAB = registerBlockWithDefaultItem("glowdust_stone_slab", () -> new SlabBlock(getProperties(GLOWDUST_STONE.get())));

--- a/src/main/java/com/nekomaster1000/infernalexp/world/gen/surfacebuilders/GlowstoneCanyonSurfaceBuilder.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/world/gen/surfacebuilders/GlowstoneCanyonSurfaceBuilder.java
@@ -49,7 +49,14 @@ public class GlowstoneCanyonSurfaceBuilder extends SurfaceBuilder<SurfaceBuilder
 
                     if (y >= seaLevel) {
                         // The typical surface of the biome.
-                        chunk.setBlockState(mutable, topBlock, false);
+                        BlockState blockBelow = chunk.getBlockState(new BlockPos(mutable.getX(), mutable.getY()-1, mutable.getZ()));
+
+                        // If the block is floating, make it Glimmer Gravel, otherwise let it be the regular surface
+                        if (blockBelow.isAir()) {
+                            chunk.setBlockState(mutable, IEBlocks.TRAPPED_GLOWDUST_SAND.get().getDefaultState(), false);
+                        } else {
+                            chunk.setBlockState(mutable, topBlock, false);
+                        }
                     } else {
                         // Makes the blocks at sealevel be dullstone to make cool border with lava.
                         if (random.nextInt(70) == 1) {

--- a/src/main/java/com/nekomaster1000/infernalexp/world/gen/surfacebuilders/GlowstoneCanyonSurfaceBuilder.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/world/gen/surfacebuilders/GlowstoneCanyonSurfaceBuilder.java
@@ -49,7 +49,9 @@ public class GlowstoneCanyonSurfaceBuilder extends SurfaceBuilder<SurfaceBuilder
 
                     if (y >= seaLevel) {
                         // The typical surface of the biome.
-                        BlockState blockBelow = chunk.getBlockState(new BlockPos(mutable.getX(), mutable.getY()-1, mutable.getZ()));
+                        mutable.down();
+                        BlockState blockBelow = chunk.getBlockState(mutable);
+                        mutable.up();
 
                         // If the block is floating, make it Glimmer Gravel, otherwise let it be the regular surface
                         if (blockBelow.isAir()) {


### PR DESCRIPTION
-Glimmer Gravel has a cascading effect and delay to falling
-Glimmer Gravel emits sparkle particles before falling
-Glimmer Gravel now replaces any floating sand in GSC gen
-Glimmer Gravel now inherits properties from sand instead of layers to allow carpets, layers, etc. to be placed on top of it