### PR TITLE
Fixed Clock Issue and Refactored Luminous Refresh Rate

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/client/DynamicLightingHandler.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/client/DynamicLightingHandler.java
@@ -22,7 +22,7 @@ public class DynamicLightingHandler {
     public static final Map<BlockPos, LightData> LIGHT_SOURCES = new ConcurrentHashMap<>();
 
     public static void tick(LivingEntity entity) {
-        if (entity != null && MinecraftInstance.player != null && MinecraftInstance.player.ticksExisted % (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_RATE.getDouble() == 0) {
+        if (entity != null && MinecraftInstance.player != null && MinecraftInstance.player.ticksExisted % (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_DELAY.getDouble() == 0) {
             if (shouldGlow(entity)) {
                 LIGHT_SOURCES.put(entity.getPosition(), new LightData(getTimeAmplifier(entity)));
             }
@@ -34,7 +34,7 @@ public class DynamicLightingHandler {
                     if (data.time == 20 * data.amplifier || !data.shouldKeep) {
                         MinecraftInstance.world.getChunkProvider().getLightManager().checkBlock(pos);                        
                     }
-                    data.time -= (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_RATE.getDouble();
+                    data.time -= (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_DELAY.getDouble();
                 });
                 LIGHT_SOURCES.entrySet().removeIf(entry -> !entry.getValue().shouldKeep);
             }
@@ -42,7 +42,7 @@ public class DynamicLightingHandler {
     }
 
     public static void tick(AbstractArrowEntity entity) {
-		if (entity != null && MinecraftInstance.player != null && MinecraftInstance.player.ticksExisted % (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_RATE.getDouble() == 0) {
+		if (entity != null && MinecraftInstance.player != null && MinecraftInstance.player.ticksExisted % (int) InfernalExpansionConfig.ClientConfig.LUMINOUS_REFRESH_DELAY.getDouble() == 0) {
 			if (shouldGlow(entity)) {
 				LIGHT_SOURCES.put(entity.getPosition(), new LightData(0.5));
 			}

--- a/src/main/java/com/nekomaster1000/infernalexp/config/ClientConfig.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/config/ClientConfig.java
@@ -6,16 +6,16 @@ import net.minecraftforge.common.ForgeConfigSpec;
 
 public class ClientConfig {
 
-    final ForgeConfigSpec.IntValue luminousRefreshRate;
+    final ForgeConfigSpec.IntValue luminousRefreshDelay;
     
     ClientConfig(final ForgeConfigSpec.Builder builder){
         builder.push("general");
 
         // Luminous Effect
-        luminousRefreshRate = builder
-                .comment("Determines how much (in ticks) the luminous effect should update")
-                .translation(InfernalExpansion.MOD_ID + ".config.tooltip.luminousRefreshRate")
-                .defineInRange("luminousRefreshRate", 2, 1, Integer.MAX_VALUE);
+        luminousRefreshDelay = builder
+                .comment("Determines how often (in ticks) the luminous effect should update")
+                .translation(InfernalExpansion.MOD_ID + ".config.tooltip.luminousRefreshDelay")
+                .defineInRange("luminousRefreshDelay", 2, 1, Integer.MAX_VALUE);
 
         builder.pop();
     }

--- a/src/main/java/com/nekomaster1000/infernalexp/config/ConfigHelper.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/config/ConfigHelper.java
@@ -15,7 +15,7 @@ public final class ConfigHelper {
     //Client
     public static void bakeClient(@Nullable final ModConfig config) {
         //Luminous Effect
-        ClientConfig.LUMINOUS_REFRESH_RATE.set(ConfigHolder.CLIENT.luminousRefreshRate.get());
+        ClientConfig.LUMINOUS_REFRESH_DELAY.set(ConfigHolder.CLIENT.luminousRefreshDelay.get());
     }
 
     //Common
@@ -84,7 +84,7 @@ public final class ConfigHelper {
     }
 
     public static void saveToClient() {
-        ConfigHolder.CLIENT.luminousRefreshRate.set((int) ClientConfig.LUMINOUS_REFRESH_RATE.getDouble());
+        ConfigHolder.CLIENT.luminousRefreshDelay.set((int) ClientConfig.LUMINOUS_REFRESH_DELAY.getDouble());
     }
 
     public static void saveToCommon() {

--- a/src/main/java/com/nekomaster1000/infernalexp/config/InfernalExpansionConfig.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/config/InfernalExpansionConfig.java
@@ -9,7 +9,7 @@ public final class InfernalExpansionConfig {
 
     //Luminous Effect
     public enum ClientConfig {
-        LUMINOUS_REFRESH_RATE("luminousRefreshRate", true, 1, 20, 1);
+        LUMINOUS_REFRESH_DELAY("luminousRefreshDelay", true, 1, 20, 1);
 
         private final String translationName;
         private final boolean isSlider;

--- a/src/main/java/com/nekomaster1000/infernalexp/mixin/client/MixinItemModelsProperties.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/mixin/client/MixinItemModelsProperties.java
@@ -1,28 +1,38 @@
 package com.nekomaster1000.infernalexp.mixin.client;
 
-import java.util.Random;
-
-import javax.annotation.Nullable;
-
+import com.nekomaster1000.infernalexp.init.IEBiomes;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-import com.nekomaster1000.infernalexp.init.IEBiomes;
-
-import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.MathHelper;
+import javax.annotation.Nullable;
+import java.util.Optional;
+import java.util.Random;
 
 @Mixin(targets = "net.minecraft.item.ItemModelsProperties$1")
 public class MixinItemModelsProperties {
 
 	@ModifyVariable(method = "call", at = @At(value = "STORE", ordinal = 1 /* this ordinal is when its set to Math.random(), the second time d0 is set to something */), ordinal = 0 /* this ordinal means the first double variable */)
 	private double IE_daytimeInGSC(double in, ItemStack stack, @Nullable ClientWorld world, @Nullable LivingEntity entity) {
-		if (world.getBiome(entity.getPosition()).getRegistryName().equals(IEBiomes.GLOWSTONE_CANYON.getId())) {
-			return MathHelper.nextDouble(new Random(), 0.95, 1.05) % 1;
-		}
+        ClientWorld clientWorld = world;
+        if (entity == null) {
+            return in;
+        }
+        if (world == null && entity.world instanceof ClientWorld) {
+	        clientWorld = (ClientWorld)entity.getEntityWorld();
+        }
+
+        Optional<RegistryKey<Biome>> biome = clientWorld.func_242406_i(entity.getPosition());
+
+	    if (biome.isPresent() && biome.get().getLocation().equals(IEBiomes.GLOWSTONE_CANYON.getId())) {
+	        return MathHelper.nextDouble(new Random(), 0.95, 1.05) % 1;
+        }
 		return in;
 	}
 }

--- a/src/main/java/com/nekomaster1000/infernalexp/mixin/client/MixinItemModelsProperties.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/mixin/client/MixinItemModelsProperties.java
@@ -20,19 +20,19 @@ public class MixinItemModelsProperties {
 
 	@ModifyVariable(method = "call", at = @At(value = "STORE", ordinal = 1 /* this ordinal is when its set to Math.random(), the second time d0 is set to something */), ordinal = 0 /* this ordinal means the first double variable */)
 	private double IE_daytimeInGSC(double in, ItemStack stack, @Nullable ClientWorld world, @Nullable LivingEntity entity) {
-        ClientWorld clientWorld = world;
+	    ClientWorld clientWorld = world;
         if (entity == null) {
             return in;
         }
         if (world == null && entity.world instanceof ClientWorld) {
-	        clientWorld = (ClientWorld)entity.getEntityWorld();
+            clientWorld = (ClientWorld)entity.getEntityWorld();
         }
 
         Optional<RegistryKey<Biome>> biome = clientWorld.func_242406_i(entity.getPosition());
 
-	    if (biome.isPresent() && biome.get().getLocation().equals(IEBiomes.GLOWSTONE_CANYON.getId())) {
-	        return MathHelper.nextDouble(new Random(), 0.95, 1.05) % 1;
+        if (biome.isPresent() && biome.get().getLocation().equals(IEBiomes.GLOWSTONE_CANYON.getId())) {
+            return MathHelper.nextDouble(new Random(), 0.95, 1.05) % 1;
         }
-		return in;
+        return in;
 	}
 }

--- a/src/main/resources/assets/infernalexp/lang/de_de.json
+++ b/src/main/resources/assets/infernalexp/lang/de_de.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/en_us.json
+++ b/src/main/resources/assets/infernalexp/lang/en_us.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/es_ar.json
+++ b/src/main/resources/assets/infernalexp/lang/es_ar.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/es_es.json
+++ b/src/main/resources/assets/infernalexp/lang/es_es.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/fr_ca.json
+++ b/src/main/resources/assets/infernalexp/lang/fr_ca.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/fr_fr.json
+++ b/src/main/resources/assets/infernalexp/lang/fr_fr.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/he_il.json
+++ b/src/main/resources/assets/infernalexp/lang/he_il.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/id_id.json
+++ b/src/main/resources/assets/infernalexp/lang/id_id.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/lol_us.json
+++ b/src/main/resources/assets/infernalexp/lang/lol_us.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/lv_lv.json
+++ b/src/main/resources/assets/infernalexp/lang/lv_lv.json
@@ -370,8 +370,8 @@
 "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
 "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-"infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-"infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+"infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+"infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
 "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
 "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/ms_my.json
+++ b/src/main/resources/assets/infernalexp/lang/ms_my.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/nl_nl.json
+++ b/src/main/resources/assets/infernalexp/lang/nl_nl.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/pl_pl.json
+++ b/src/main/resources/assets/infernalexp/lang/pl_pl.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/pt_br.json
+++ b/src/main/resources/assets/infernalexp/lang/pt_br.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/ru_ru.json
+++ b/src/main/resources/assets/infernalexp/lang/ru_ru.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Определяет длительность эффекта от вяленого мяса",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Определяет силу эффекта от вяленого мяса",
 
-  "infernalexp.config.option.luminousRefreshRate": "Скорость обновления эффекта Свечения",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Определяет, как долго (в тиках) эффект свечения обновляется",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/assets/infernalexp/lang/zh_tw.json
+++ b/src/main/resources/assets/infernalexp/lang/zh_tw.json
@@ -370,8 +370,8 @@
   "infernalexp.config.tooltip.jerkyEffectDuration": "Determines the duration in seconds of the effect that Cured Jerky gives",
   "infernalexp.config.tooltip.jerkyEffectAmplifier": "Determines the amplifier of the effect that Cured Jerky gives",
 
-  "infernalexp.config.option.luminousRefreshRate": "Luminous Effect Refresh Rate",
-  "infernalexp.config.tooltip.luminousRefreshRate": "Determines how much (in ticks) the luminous effect should update",
+  "infernalexp.config.option.luminousRefreshDelay": "Luminous Effect Refresh Delay",
+  "infernalexp.config.tooltip.luminousRefreshDelay": "Determines how often (in ticks) the luminous effect should update",
 
   "infernalexp.config.option.luminousFungusGivesEffect": "Luminous Fungus gives Luminance Effect",
   "infernalexp.config.tooltip.luminousFungusGivesEffect": "Determines whether Luminous Fungus gives the Luminance effect on collision with an entity",

--- a/src/main/resources/infernal-expansion.mixins.json
+++ b/src/main/resources/infernal-expansion.mixins.json
@@ -29,6 +29,7 @@
     "client.MixinModelBakery",
     "client.MixinOverlayRenderer",
     "client.MixinPaintingSpriteUploader",
-    "client.MixinPlayerRenderer"
+    "client.MixinPlayerRenderer",
+    "client.MixinItemModelsProperties"
   ]
 }

--- a/src/main/resources/infernal-expansion.mixins.json
+++ b/src/main/resources/infernal-expansion.mixins.json
@@ -26,10 +26,10 @@
     "client.MixinClientPlayNetHandler",
     "client.MixinEntityRendererManager",
     "client.MixinIBlockReader",
+    "client.MixinItemModelsProperties",
     "client.MixinModelBakery",
     "client.MixinOverlayRenderer",
     "client.MixinPaintingSpriteUploader",
-    "client.MixinPlayerRenderer",
-    "client.MixinItemModelsProperties"
+    "client.MixinPlayerRenderer"
   ]
 }


### PR DESCRIPTION
-Grabbed Biome from the registry key in clock mixin since getResourceLocation was returning null
-Added extra checks to make sure that there shouldn't be a NullPointerException
-Refactored Luminous Refresh Rate to Luminous Refresh Delay for clarity
-Updated lang files to match this refactor