### PR TITLE
Finally Fix The Stupid Targeting Crash

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TeleportPanicGoal.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/ai/TeleportPanicGoal.java
@@ -2,11 +2,8 @@ package com.nekomaster1000.infernalexp.entities.ai;
 
 import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.ai.RandomPositionGenerator;
-import net.minecraft.entity.ai.goal.MeleeAttackGoal;
 import net.minecraft.entity.ai.goal.PanicGoal;
 import net.minecraft.util.math.vector.Vector3d;
-
-import java.util.List;
 
 public class TeleportPanicGoal extends PanicGoal {
 
@@ -19,7 +16,6 @@ public class TeleportPanicGoal extends PanicGoal {
         this.creature.attemptTeleport(this.randPosX, this.randPosY, this.randPosZ, true); //Final parameter determines whether or not purple enderman particles appear on teleport
         this.creature.setMotion(0.0D, 0.0D, 0.0D);
         this.creature.setRevengeTarget(null);
-        removeTargeting();
     }
 
     @Override
@@ -38,21 +34,6 @@ public class TeleportPanicGoal extends PanicGoal {
             this.randPosZ = vector3d.z;
 
             return true;
-        }
-    }
-
-    private void removeTargeting() {
-        List<CreatureEntity> list = this.creature.world.getEntitiesWithinAABB(CreatureEntity.class,
-                this.creature.getBoundingBox().grow(32.0D));
-
-        for (CreatureEntity entity : list) {
-            if (entity.getAttackTarget() == this.creature) {
-                entity.goalSelector.getRunningGoals().forEach(runningGoal -> {
-                    if (runningGoal.getGoal() instanceof MeleeAttackGoal) {
-                        runningGoal.resetTask();
-                    }
-                });
-            }
         }
     }
 }

--- a/src/main/java/com/nekomaster1000/infernalexp/events/MobEvents.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/events/MobEvents.java
@@ -12,16 +12,13 @@ import com.nekomaster1000.infernalexp.entities.VolineEntity;
 import com.nekomaster1000.infernalexp.entities.WarpbeetleEntity;
 import com.nekomaster1000.infernalexp.entities.ai.AvoidBlockGoal;
 import com.nekomaster1000.infernalexp.init.IETags;
-import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.EntityType;
-import net.minecraft.entity.FlyingEntity;
 import net.minecraft.entity.ai.goal.AvoidEntityGoal;
 import net.minecraft.entity.ai.goal.NearestAttackableTargetGoal;
 import net.minecraft.entity.monster.GhastEntity;
 import net.minecraft.entity.monster.HoglinEntity;
 import net.minecraft.entity.monster.MagmaCubeEntity;
 import net.minecraft.entity.monster.SkeletonEntity;
-import net.minecraft.entity.monster.SlimeEntity;
 import net.minecraft.entity.monster.SpiderEntity;
 import net.minecraft.entity.monster.piglin.PiglinBruteEntity;
 import net.minecraft.entity.monster.piglin.PiglinEntity;
@@ -44,138 +41,136 @@ public class MobEvents {
 	@SubscribeEvent
 	public void onEntityJoin(EntityJoinWorldEvent event) {
 
-		//
-		//RUN AWAY!!
-		//
+        //
+        //RUN AWAY!!
+        //
 
-		//Piglins fear Warpbeetles and Embodies
-		if (event.getEntity() instanceof PiglinEntity){
-			if (MobInteractions.PIGLIN_FEAR_WARPBEETLE.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-						new AvoidEntityGoal<>((CreatureEntity) event.getEntity(),
-								WarpbeetleEntity.class, 16.0F, 1.2D, 1.2D));
-			}
-			if (MobInteractions.PIGLIN_FEAR_EMBODY.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-						new AvoidEntityGoal<>((CreatureEntity) event.getEntity(),
-								EmbodyEntity.class, 16.0F, 1.2D, 1.2D));
-			}
-            if (MobInteractions.PIGLIN_FEAR_DWARF.getBoolean()) {
-                ((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-                    new AvoidEntityGoal<>((CreatureEntity) event.getEntity(),
-                        BlackstoneDwarfEntity.class, 16.0F, 1.2D, 1.2D));
-            }
-		}
-
-		if (event.getEntity() instanceof HoglinEntity){
-			if (MobInteractions.HOGLIN_FEAR_WARPBEETLE.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-						new AvoidEntityGoal<>((CreatureEntity) event.getEntity(),
-								WarpbeetleEntity.class, 16.0F, 1.2D, 1.2D));
-			}
-			if (MobInteractions.HOGLIN_FEAR_EMBODY.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-						new AvoidEntityGoal<>((CreatureEntity) event.getEntity(),
-								EmbodyEntity.class, 16.0F, 1.2D, 1.2D));
-			}
-		}
-
-		//
-		//ATTACK!!
-		//
-
-		//Spiders attack Warp beetles
-		if (event.getEntity() instanceof SpiderEntity && MobInteractions.SPIDER_ATTACK_WARPBEETLE.getBoolean()) {
-			((CreatureEntity) event.getEntity()).goalSelector.addGoal(4,
-					new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-							WarpbeetleEntity.class, true, false));
-
-		}
-
-
-		//Skeletons attacks Piglins, Brutes, Embodies & Basalt Giants
-		if (event.getEntity() instanceof SkeletonEntity) {
-			if (MobInteractions.SKELETON_ATTACK_PIGLIN.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								PiglinEntity.class, true, false));
-			}
-			if (MobInteractions.SKELETON_ATTACK_BRUTE.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								PiglinBruteEntity.class, true, false));
-			}
-			if (MobInteractions.SKELETON_ATTACK_EMBODY.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(3,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								EmbodyEntity.class, true, false));
-			}
-			if (MobInteractions.SKELETON_ATTACK_GIANT.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								BasaltGiantEntity.class, true, false));
-			}
-		}
-
-		//Piglins attack Skeletons & Voline
-		if (event.getEntity() instanceof PiglinEntity) {
-			if (MobInteractions.PIGLIN_ATTACK_SKELETON.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								SkeletonEntity.class, true, false));
-			}
-			if (MobInteractions.PIGLIN_ATTACK_VOLINE.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								VolineEntity.class, true, false));
-			}
-		}
-
-		if (event.getEntity() instanceof PiglinBruteEntity){
-			if (MobInteractions.BRUTE_ATTACK_SKELETON.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								SkeletonEntity.class, true, false));
-			}
-			if (MobInteractions.BRUTE_ATTACK_VOLINE.getBoolean()) {
-				((CreatureEntity) event.getEntity()).goalSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((CreatureEntity) event.getEntity(),
-								VolineEntity.class, true, false));
-			}
-		}
-
-
-		//Ghasts attack Voline, Embodies, Skeletons
-		if (event.getEntity() instanceof GhastEntity) {
-		    if (MobInteractions.GHAST_ATTACK_GLOWSQUITO.getBoolean()) {
-                ((FlyingEntity) event.getEntity()).targetSelector.addGoal(4,
-                    new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
-                        GlowsquitoEntity.class, true, false));
+            //Piglins fear Warpbeetles and Embodies
+            if (event.getEntity() instanceof PiglinEntity) {
+                if (MobInteractions.PIGLIN_FEAR_WARPBEETLE.getBoolean()) {
+                    ((PiglinEntity) event.getEntity()).goalSelector.addGoal(4,
+                        new AvoidEntityGoal<>((PiglinEntity) event.getEntity(),
+                            WarpbeetleEntity.class, 16.0F, 1.2D, 1.2D));
+                }
+                if (MobInteractions.PIGLIN_FEAR_EMBODY.getBoolean()) {
+                    ((PiglinEntity) event.getEntity()).goalSelector.addGoal(4,
+                        new AvoidEntityGoal<>((PiglinEntity) event.getEntity(),
+                            EmbodyEntity.class, 16.0F, 1.2D, 1.2D));
+                }
+                if (MobInteractions.PIGLIN_FEAR_DWARF.getBoolean()) {
+                    ((PiglinEntity) event.getEntity()).goalSelector.addGoal(4,
+                        new AvoidEntityGoal<>((PiglinEntity) event.getEntity(),
+                            BlackstoneDwarfEntity.class, 16.0F, 1.2D, 1.2D));
+                }
             }
 
-			if (MobInteractions.GHAST_ATTACK_EMBODY.getBoolean()) {
-				((FlyingEntity) event.getEntity()).targetSelector.addGoal(3,
-						new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
-								EmbodyEntity.class, true, false));
-			}
-			if (MobInteractions.GHAST_ATTACK_VOLINE.getBoolean()) {
-				((FlyingEntity) event.getEntity()).targetSelector.addGoal(2,
-						new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
-								VolineEntity.class, true, false));
-			}
-			if (MobInteractions.GHAST_ATTACK_SKELETON.getBoolean()) {
-				((FlyingEntity) event.getEntity()).targetSelector.addGoal(3,
-						new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
-								SkeletonEntity.class, true, false));
-			}
-		}
+            if (event.getEntity() instanceof HoglinEntity) {
+                if (MobInteractions.HOGLIN_FEAR_WARPBEETLE.getBoolean()) {
+                    ((HoglinEntity) event.getEntity()).goalSelector.addGoal(4,
+                        new AvoidEntityGoal<>((HoglinEntity) event.getEntity(),
+                            WarpbeetleEntity.class, 16.0F, 1.2D, 1.2D));
+                }
+                if (MobInteractions.HOGLIN_FEAR_EMBODY.getBoolean()) {
+                    ((HoglinEntity) event.getEntity()).goalSelector.addGoal(4,
+                        new AvoidEntityGoal<>((HoglinEntity) event.getEntity(),
+                            EmbodyEntity.class, 16.0F, 1.2D, 1.2D));
+                }
+            }
 
-		if (event.getEntity() instanceof MagmaCubeEntity) {
-			((SlimeEntity) event.getEntity()).goalSelector.addGoal(0,
-					new AvoidBlockGoal((SlimeEntity) event.getEntity(), IETags.Blocks.MAGMA_CUBE_AVOID_BLOCKS,
-							8));
-        }
+            //
+            //ATTACK!!
+            //
 
+            //Spiders attack Warp beetles
+            if (event.getEntity() instanceof SpiderEntity && MobInteractions.SPIDER_ATTACK_WARPBEETLE.getBoolean()) {
+                ((SpiderEntity) event.getEntity()).targetSelector.addGoal(4,
+                    new NearestAttackableTargetGoal<>((SpiderEntity) event.getEntity(),
+                        WarpbeetleEntity.class, true, false));
+            }
+
+
+            //Skeletons attacks Piglins, Brutes, Embodies & Basalt Giants
+            if (event.getEntity() instanceof SkeletonEntity) {
+                if (MobInteractions.SKELETON_ATTACK_PIGLIN.getBoolean()) {
+                    ((SkeletonEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((SkeletonEntity) event.getEntity(),
+                            PiglinEntity.class, true, false));
+                }
+                if (MobInteractions.SKELETON_ATTACK_BRUTE.getBoolean()) {
+                    ((SkeletonEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((SkeletonEntity) event.getEntity(),
+                            PiglinBruteEntity.class, true, false));
+                }
+                if (MobInteractions.SKELETON_ATTACK_EMBODY.getBoolean()) {
+                    ((SkeletonEntity) event.getEntity()).targetSelector.addGoal(3,
+                        new NearestAttackableTargetGoal<>((SkeletonEntity) event.getEntity(),
+                            EmbodyEntity.class, true, false));
+                }
+                if (MobInteractions.SKELETON_ATTACK_GIANT.getBoolean()) {
+                    ((SkeletonEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((SkeletonEntity) event.getEntity(),
+                            BasaltGiantEntity.class, true, false));
+                }
+            }
+
+            //Piglins attack Skeletons & Voline
+            if (event.getEntity() instanceof PiglinEntity) {
+                if (MobInteractions.PIGLIN_ATTACK_SKELETON.getBoolean()) {
+                    ((PiglinEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((PiglinEntity) event.getEntity(),
+                            SkeletonEntity.class, true, false));
+                }
+                if (MobInteractions.PIGLIN_ATTACK_VOLINE.getBoolean()) {
+                    ((PiglinEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((PiglinEntity) event.getEntity(),
+                            VolineEntity.class, true, false));
+                }
+            }
+
+            if (event.getEntity() instanceof PiglinBruteEntity) {
+                if (MobInteractions.BRUTE_ATTACK_SKELETON.getBoolean()) {
+                    ((PiglinBruteEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((PiglinBruteEntity) event.getEntity(),
+                            SkeletonEntity.class, true, false));
+                }
+                if (MobInteractions.BRUTE_ATTACK_VOLINE.getBoolean()) {
+                    ((PiglinBruteEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((PiglinBruteEntity) event.getEntity(),
+                            VolineEntity.class, true, false));
+                }
+            }
+
+
+            //Ghasts attack Voline, Embodies, Skeletons
+            if (event.getEntity() instanceof GhastEntity) {
+                if (MobInteractions.GHAST_ATTACK_GLOWSQUITO.getBoolean()) {
+                    ((GhastEntity) event.getEntity()).targetSelector.addGoal(4,
+                        new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
+                            GlowsquitoEntity.class, true, false));
+                }
+
+                if (MobInteractions.GHAST_ATTACK_EMBODY.getBoolean()) {
+                    ((GhastEntity) event.getEntity()).targetSelector.addGoal(3,
+                        new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
+                            EmbodyEntity.class, true, false));
+                }
+                if (MobInteractions.GHAST_ATTACK_VOLINE.getBoolean()) {
+                    ((GhastEntity) event.getEntity()).targetSelector.addGoal(2,
+                        new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
+                            VolineEntity.class, true, false));
+                }
+                if (MobInteractions.GHAST_ATTACK_SKELETON.getBoolean()) {
+                    ((GhastEntity) event.getEntity()).targetSelector.addGoal(3,
+                        new NearestAttackableTargetGoal<>((GhastEntity) event.getEntity(),
+                            SkeletonEntity.class, true, false));
+                }
+            }
+
+            if (event.getEntity() instanceof MagmaCubeEntity) {
+                ((MagmaCubeEntity) event.getEntity()).goalSelector.addGoal(0,
+                    new AvoidBlockGoal((MagmaCubeEntity) event.getEntity(), IETags.Blocks.MAGMA_CUBE_AVOID_BLOCKS,
+                        8));
+            }
 	}
 
     private void addEntityToSpawner(BiomeLoadingEvent event, EntityType<?> entityType, SpawnrateManager.SpawnInfo spawnInfo) {


### PR DESCRIPTION
-Changed all target goals to targetSelector instead of goalSelector
-Removed unnecessary removeTargeting from TeleportPanicGoal since that's not actually the bug fix
-In MobEvents, cast event.getEntity to respective entity type in each goal setter instead of generic CreatureEntity