### PR TITLE
Fixed Whip Animation Bugs

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/client/InfernalExpansionClient.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/client/InfernalExpansionClient.java
@@ -36,11 +36,11 @@ public class InfernalExpansionClient {
         ItemModelsProperties.registerProperty(IEItems.GLOWSILK_BOW.get(), new ResourceLocation("pulling"), (itemStack, clientWorld, livingEntity) -> livingEntity != null && livingEntity.isHandActive() && livingEntity.getActiveItemStack() == itemStack ? 1.0F : 0.0F);
 
         ItemModelsProperties.registerProperty(IEItems.BLINDSIGHT_TONGUE_WHIP.get(), new ResourceLocation("attack_frame"), (itemStack, clientWorld, livingEntity) ->
-            livingEntity == null || livingEntity.getHeldItemMainhand() != itemStack ?
+            livingEntity == null || (livingEntity.getHeldItemMainhand() != itemStack && livingEntity.getHeldItemOffhand() != itemStack) ?
                 0 : (int) (((WhipItem) itemStack.getItem()).getTicksSinceAttack(itemStack) / 6.0F)
         );
 
-        ItemModelsProperties.registerProperty(IEItems.BLINDSIGHT_TONGUE_WHIP.get(), new ResourceLocation("attacking"), (itemStack, clientWorld, livingEntity) -> livingEntity != null && (((WhipItem) itemStack.getItem()).getAttacking(itemStack) || ((WhipItem) itemStack.getItem()).getCharging(itemStack)) && livingEntity.getHeldItemMainhand() == itemStack ? 1.0F : 0.0F);
+        ItemModelsProperties.registerProperty(IEItems.BLINDSIGHT_TONGUE_WHIP.get(), new ResourceLocation("attacking"), (itemStack, clientWorld, livingEntity) -> livingEntity != null && (((WhipItem) itemStack.getItem()).getAttacking(itemStack) || ((WhipItem) itemStack.getItem()).getCharging(itemStack)) && (livingEntity.getHeldItemMainhand() == itemStack || livingEntity.getHeldItemOffhand() == itemStack) ? 1.0F : 0.0F);
 
         InfernalExpansionClient.loadInfernalResources();
     }

--- a/src/main/java/com/nekomaster1000/infernalexp/items/WhipItem.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/items/WhipItem.java
@@ -145,15 +145,11 @@ public class WhipItem extends TieredItem implements IVanishable {
 
     @Override
     public void inventoryTick(ItemStack stack, World worldIn, Entity entityIn, int itemSlot, boolean isSelected) {
-        if (!isSelected) {
-            return;
-        }
-
         if ((getCharging(stack) && getTicksSinceAttack(stack) <= 30) || getAttacking(stack)) {
             setTicksSinceAttack(stack, getTicksSinceAttack(stack) + 1);
         }
 
-        if (getTicksSinceAttack(stack) >= 60) {
+        if (getTicksSinceAttack(stack) >= 60 || (!isSelected && entityIn instanceof PlayerEntity && ((PlayerEntity) entityIn).getHeldItemOffhand() != stack)) {
             setTicksSinceAttack(stack, 0);
             setAttacking(stack, false);
             setCharging(stack, false);


### PR DESCRIPTION
-Changed !isSelected check to reset the animation if the whip is no longer selected and isn't in the offhand, since the offhand is never considered as selected
-This causes the animation to reset if you switch hotbar spaces mid-animation, but also allows the offhand animation to continue normally even if you switch spaces, much like a bow
-Adjusted ItemModelsProperties to check both hands instead of just the main hand to animate offhand