### PR TITLE
Removed a dependency on SpongePowered's Noise. (org.spongepowered:noise)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,6 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
 
-    implementation 'org.spongepowered:noise:2.0.0-SNAPSHOT'
-
     compile 'org.spongepowered:mixin:0.8.1'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..


### PR DESCRIPTION
The dependency is completely unnecessary, as it is not used anywhere in code. It was added with commit 121610a90910dc424d52fcf96c00572988680109.