### PR TITLE
Fixed Voline Eat Table

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/entities/VolineEntity.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/VolineEntity.java
@@ -32,11 +32,13 @@ import net.minecraft.entity.monster.piglin.AbstractPiglinEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.particles.ParticleTypes;
+import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.DamageSource;
@@ -281,6 +283,11 @@ public class VolineEntity extends MonsterEntity implements IBucketable {
 			// Super call here so that we can get a reference of the item before the item
 			// instance is deleted
 			super.consumeItem();
+
+            if (itemReference == Items.GOLDEN_APPLE) {
+                entityIn.addPotionEffect(new EffectInstance(Effects.REGENERATION, 100, 1));
+                entityIn.addPotionEffect(new EffectInstance(Effects.ABSORPTION, 2400, 0));
+            }
 
             Map<Item, Integer> eatItem = eatItemsMap.get(itemReference);
 

--- a/src/main/resources/data/infernalexp/loot_tables/gameplay/voline_eat_table.json
+++ b/src/main/resources/data/infernalexp/loot_tables/gameplay/voline_eat_table.json
@@ -13,7 +13,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 4
+          "amount": 1
         }
       ]
     },
@@ -21,12 +21,8 @@
       "accepted_item": "minecraft:gold_block",
       "returned_items": [
         {
-          "item": "minecraft:gold_ingot",
-          "amount": 4
-        },
-        {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 4
+          "amount": 9
         }
       ]
     },
@@ -35,7 +31,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 4
+          "amount": 3
         }
       ]
     },
@@ -44,7 +40,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 4
+          "amount": 3
         }
       ]
     },
@@ -53,7 +49,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 9
+          "amount": 3
         }
       ]
     },
@@ -62,7 +58,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 9
+          "amount": 3
         }
       ]
     },
@@ -71,7 +67,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 5
+          "amount": 2
         }
       ]
     },
@@ -80,7 +76,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 5
+          "amount": 2
         }
       ]
     },
@@ -89,7 +85,7 @@
       "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 2
+          "amount": 1
         }
       ]
     },
@@ -97,12 +93,8 @@
       "accepted_item": "minecraft:golden_helmet",
       "returned_items": [
         {
-          "item": "minecraft:gold_ingot",
-          "amount": 2
-        },
-        {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 4
+          "amount": 5
         }
       ]
     },
@@ -110,12 +102,8 @@
       "accepted_item": "minecraft:golden_chestplate",
       "returned_items": [
         {
-          "item": "minecraft:gold_ingot",
-          "amount": 4
-        },
-        {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 2
+          "amount": 8
         }
       ]
     },
@@ -123,12 +111,8 @@
       "accepted_item": "minecraft:golden_leggings",
       "returned_items": [
         {
-          "item": "minecraft:gold_ingot",
-          "amount": 2
-        },
-        {
           "item": "infernalexp:molten_gold_cluster",
-          "amount": 9
+          "amount": 7
         }
       ]
     },
@@ -136,9 +120,77 @@
       "accepted_item": "minecraft:golden_boots",
       "returned_items": [
         {
-          "item": "minecraft:gold_ingot",
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 4
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:golden_horse_armor",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 6
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:light_weighted_pressure_plate",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
           "amount": 2
-        },
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:powered_rail",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 6
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:bell",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 7
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:gilded_blackstone",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 1
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:clock",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 4
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:golden_carrot",
+      "returned_items": [
+        {
+          "item": "infernalexp:molten_gold_cluster",
+          "amount": 1
+        }
+      ]
+    },
+    {
+      "accepted_item": "minecraft:golden_apple",
+      "returned_items": [
         {
           "item": "infernalexp:molten_gold_cluster",
           "amount": 2

--- a/src/main/resources/data/infernalexp/recipes/crafting/crafting_shaped/gold_ingots_from_molten_gold_cluster.json
+++ b/src/main/resources/data/infernalexp/recipes/crafting/crafting_shaped/gold_ingots_from_molten_gold_cluster.json
@@ -16,6 +16,6 @@
   "result":
   {
     "item": "minecraft:gold_ingot",
-    "count": 2
+    "count": 3
   }
 }

--- a/src/main/resources/data/infernalexp/recipes/crafting/crafting_shapeless/gold_ingot_from_molten_cluster_1.json
+++ b/src/main/resources/data/infernalexp/recipes/crafting/crafting_shapeless/gold_ingot_from_molten_cluster_1.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients":
+  [
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    }
+  ],
+  "result":
+  {
+    "item": "minecraft:gold_ingot",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/infernalexp/recipes/crafting/crafting_shapeless/gold_ingot_from_molten_cluster_2.json
+++ b/src/main/resources/data/infernalexp/recipes/crafting/crafting_shapeless/gold_ingot_from_molten_cluster_2.json
@@ -1,0 +1,29 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients":
+  [
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    },
+    {
+      "item": "infernalexp:molten_gold_cluster"
+    }
+  ],
+  "result":
+  {
+    "item": "minecraft:gold_ingot",
+    "count": 2
+  }
+}


### PR DESCRIPTION
-Fixed Voline Eat Table values
-Changed value of Molten Gold Cluster to 1/3 of an ingot instead of 2/9
-Added new items to the eat table
-Added feature where Voline gets Golden Apple effects when it eats a Golden Apple
-Changed existing crafting recipe for molten gold cluster to output 3 ingots
-Created two new recipes that allow the player to craft 1 or 2 ingots with MGC