### PR TITLE
Embody Fall Prevention

### DIFF
--- a/src/main/java/com/nekomaster1000/infernalexp/entities/EmbodyEntity.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/entities/EmbodyEntity.java
@@ -3,6 +3,7 @@ package com.nekomaster1000.infernalexp.entities;
 import com.nekomaster1000.infernalexp.config.InfernalExpansionConfig;
 import com.nekomaster1000.infernalexp.init.IESoundEvents;
 
+import com.nekomaster1000.infernalexp.init.IETags;
 import net.minecraft.entity.CreatureAttribute;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ILivingEntityData;
@@ -74,7 +75,15 @@ public class EmbodyEntity extends MonsterEntity {
 		return ((double) 0.45F + this.rand.nextDouble() * 0.3D + this.rand.nextDouble() * 0.3D + this.rand.nextDouble() * 0.3D) * 0.50D;
 	}
 
-	public boolean isImmuneToFire() {
+    @Override
+    public boolean attackEntityFrom(DamageSource source, float amount) {
+	    if (source.getDamageType().equals("fall") && this.getStateBelow().getBlock().isIn(IETags.Blocks.EMBODY_FALL_BLOCKS)) {
+	        return false;
+        }
+        return super.attackEntityFrom(source, amount);
+    }
+
+    public boolean isImmuneToFire() {
 		return true;
 	}
 

--- a/src/main/java/com/nekomaster1000/infernalexp/init/IETags.java
+++ b/src/main/java/com/nekomaster1000/infernalexp/init/IETags.java
@@ -23,6 +23,7 @@ public class IETags {
         public static final ITag.INamedTag<Block> ANGER_LUMINOUS_SHROOMLOIN_BLOCKS = tag("anger_luminous_shroomloin_blocks");
         public static final ITag.INamedTag<Block> ANGER_RED_SHROOMLOIN_BLOCKS = tag("anger_red_shroomloin_blocks");
         public static final ITag.INamedTag<Block> ANGER_BROWN_SHROOMLOIN_BLOCKS = tag("anger_brown_shroomloin_blocks");
+        public static final ITag.INamedTag<Block> EMBODY_FALL_BLOCKS = tag("embody_fall_blocks");
 
         private static ITag.INamedTag<Block> tag(String name) {
             return BlockTags.createOptional(new ResourceLocation(InfernalExpansion.MOD_ID, name));

--- a/src/main/resources/data/infernalexp/tags/blocks/embody_fall_blocks.json
+++ b/src/main/resources/data/infernalexp/tags/blocks/embody_fall_blocks.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:soul_sand",
+    "minecraft:soul_soil",
+    "infernalexp:soul_soil_path"
+  ]
+}


### PR DESCRIPTION
-Embodies don't take fall damage when falling on certain blocks
-Created a tag to easily manage the blocks it can fall on as well as let other mods add to it