### PR TITLE
Added PostRightClickBlockEvent

### DIFF
--- a/src/main/java/org/infernalstudios/infernalexp/events/MiscEvents.java
+++ b/src/main/java/org/infernalstudios/infernalexp/events/MiscEvents.java
@@ -172,7 +172,7 @@ public class MiscEvents {
 
 
     @SubscribeEvent
-    public void onRightClickBlock(RightClickBlockAfterActionEvent event) {
+    public void onRightClickBlock(PostRightClickBlockEvent event) {
         ItemStack heldItemStack = event.getItemStack();
         World world = event.getWorld();
         BlockPos pos = event.getPos();

--- a/src/main/java/org/infernalstudios/infernalexp/events/MiscEvents.java
+++ b/src/main/java/org/infernalstudios/infernalexp/events/MiscEvents.java
@@ -172,12 +172,13 @@ public class MiscEvents {
 
 
     @SubscribeEvent
-    public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
+    public void onRightClickBlock(RightClickBlockAfterActionEvent event) {
         ItemStack heldItemStack = event.getItemStack();
         World world = event.getWorld();
         BlockPos pos = event.getPos();
         Direction face = event.getFace();
         PlayerEntity player = event.getPlayer();
+
         if (heldItemStack.getItem() == Items.BONE) {
             pos = pos.offset(face);
             BlockState blockstate = IEBlocks.BURIED_BONE.get().getPlaceableState(world, pos, face);

--- a/src/main/java/org/infernalstudios/infernalexp/events/PostRightClickBlockEvent.java
+++ b/src/main/java/org/infernalstudios/infernalexp/events/PostRightClickBlockEvent.java
@@ -26,7 +26,7 @@ import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 
-public class RightClickBlockAfterActionEvent extends PlayerEvent {
+public class PostRightClickBlockEvent extends PlayerEvent {
 
     private final Hand hand;
     private final BlockPos pos;
@@ -36,10 +36,10 @@ public class RightClickBlockAfterActionEvent extends PlayerEvent {
      * This event is only fired if there was no right click action for the targeted block.
      * This event won't fire if {@link net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock} has set the useItem {@link net.minecraftforge.eventbus.api.Event.Result} to DENY
      */
-    public RightClickBlockAfterActionEvent(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult hitVec) {
-        super(Preconditions.checkNotNull(player, "Null player in RightClickBlockAfterActionEvent!"));
-        this.hand = Preconditions.checkNotNull(hand, "Null hand in RightClickBlockAfterActionEvent!");
-        this.pos = Preconditions.checkNotNull(pos, "Null position in RightClickBlockAfterActionEvent!");
+    public PostRightClickBlockEvent(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult hitVec) {
+        super(Preconditions.checkNotNull(player, "Null player in PostRightClickBlockEvent!"));
+        this.hand = Preconditions.checkNotNull(hand, "Null hand in PostRightClickBlockEvent!");
+        this.pos = Preconditions.checkNotNull(pos, "Null position in PostRightClickBlockEvent!");
         this.hitVec = hitVec;
     }
 

--- a/src/main/java/org/infernalstudios/infernalexp/events/RightClickBlockAfterActionEvent.java
+++ b/src/main/java/org/infernalstudios/infernalexp/events/RightClickBlockAfterActionEvent.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Infernal Studios
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.infernalstudios.infernalexp.events;
+
+import com.google.common.base.Preconditions;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Direction;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.world.World;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+
+public class RightClickBlockAfterActionEvent extends PlayerEvent {
+
+    private final Hand hand;
+    private final BlockPos pos;
+    private final BlockRayTraceResult hitVec;
+
+    /**
+     * This event is only fired if there was no right click action for the targeted block.
+     * This event won't fire if {@link net.minecraftforge.event.entity.player.PlayerInteractEvent.RightClickBlock} has set the useItem {@link net.minecraftforge.eventbus.api.Event.Result} to DENY
+     */
+    public RightClickBlockAfterActionEvent(PlayerEntity player, Hand hand, BlockPos pos, BlockRayTraceResult hitVec) {
+        super(Preconditions.checkNotNull(player, "Null player in RightClickBlockAfterActionEvent!"));
+        this.hand = Preconditions.checkNotNull(hand, "Null hand in RightClickBlockAfterActionEvent!");
+        this.pos = Preconditions.checkNotNull(pos, "Null position in RightClickBlockAfterActionEvent!");
+        this.hitVec = hitVec;
+    }
+
+    public Hand getHand() {
+        return hand;
+    }
+
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    public BlockRayTraceResult getHitVec() {
+        return hitVec;
+    }
+
+    public Direction getFace() {
+        return getHitVec().getFace();
+    }
+
+    public ItemStack getItemStack() {
+        return getPlayer().getHeldItem(getHand());
+    }
+
+    public World getWorld() {
+        return getPlayer().getEntityWorld();
+    }
+}

--- a/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinPlayerController.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinPlayerController.java
@@ -23,7 +23,7 @@ import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraftforge.common.MinecraftForge;
-import org.infernalstudios.infernalexp.events.RightClickBlockAfterActionEvent;
+import org.infernalstudios.infernalexp.events.PostRightClickBlockEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -33,8 +33,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class MixinPlayerController {
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameType;isCreative()Z"), method = "func_217292_a")
-    private void IE_fireRightClickBlockAfterActionEventClient(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
-        MinecraftForge.EVENT_BUS.post(new RightClickBlockAfterActionEvent(player, hand, hitVec.getPos(), hitVec));
+    private void IE_firePostRightClickBlockEventClient(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
+        MinecraftForge.EVENT_BUS.post(new PostRightClickBlockEvent(player, hand, hitVec.getPos(), hitVec));
     }
 
 }

--- a/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinPlayerController.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinPlayerController.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Infernal Studios
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.infernalstudios.infernalexp.mixin.client;
+
+import net.minecraft.client.entity.player.ClientPlayerEntity;
+import net.minecraft.client.multiplayer.PlayerController;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraftforge.common.MinecraftForge;
+import org.infernalstudios.infernalexp.events.RightClickBlockAfterActionEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerController.class)
+public class MixinPlayerController {
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/GameType;isCreative()Z"), method = "func_217292_a")
+    private void IE_fireRightClickBlockAfterActionEventClient(ClientPlayerEntity player, ClientWorld world, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
+        MinecraftForge.EVENT_BUS.post(new RightClickBlockAfterActionEvent(player, hand, hitVec.getPos(), hitVec));
+    }
+
+}

--- a/src/main/java/org/infernalstudios/infernalexp/mixin/common/MixinPlayerInteractionManager.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/common/MixinPlayerInteractionManager.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Infernal Studios
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.infernalstudios.infernalexp.mixin.common;
+
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.management.PlayerInteractionManager;
+import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockRayTraceResult;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import org.infernalstudios.infernalexp.events.RightClickBlockAfterActionEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerInteractionManager.class)
+public class MixinPlayerInteractionManager {
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/PlayerInteractionManager;isCreative()Z"), method = "func_219441_a")
+    private void IE_fireRightClickBlockAfterActionEventServer(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
+        MinecraftForge.EVENT_BUS.post(new RightClickBlockAfterActionEvent(player, hand, hitVec.getPos(), hitVec));
+    }
+
+}

--- a/src/main/java/org/infernalstudios/infernalexp/mixin/common/MixinPlayerInteractionManager.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/common/MixinPlayerInteractionManager.java
@@ -24,7 +24,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-import org.infernalstudios.infernalexp.events.RightClickBlockAfterActionEvent;
+import org.infernalstudios.infernalexp.events.PostRightClickBlockEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -33,8 +33,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(PlayerInteractionManager.class)
 public class MixinPlayerInteractionManager {
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/management/PlayerInteractionManager;isCreative()Z"), method = "func_219441_a")
-    private void IE_fireRightClickBlockAfterActionEventServer(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
-        MinecraftForge.EVENT_BUS.post(new RightClickBlockAfterActionEvent(player, hand, hitVec.getPos(), hitVec));
+    private void IE_firePostRightClickBlockEventServer(ServerPlayerEntity player, World world, ItemStack stack, Hand hand, BlockRayTraceResult hitVec, CallbackInfoReturnable<ActionResultType> cir) {
+        MinecraftForge.EVENT_BUS.post(new PostRightClickBlockEvent(player, hand, hitVec.getPos(), hitVec));
     }
 
 }

--- a/src/main/resources/infernal-expansion.mixins.json
+++ b/src/main/resources/infernal-expansion.mixins.json
@@ -19,6 +19,7 @@
     "common.MixinEntity",
     "common.MixinMagmaCubeEntity",
     "common.MixinPaintingEntity",
+    "common.MixinPlayerInteractionManager",
     "common.MixinShearsItem",
     "common.MixinShovelItem",
     "common.MixinStriderEntity",
@@ -32,6 +33,7 @@
     "client.MixinModelBakery",
     "client.MixinOverlayRenderer",
     "client.MixinPaintingSpriteUploader",
+    "client.MixinPlayerController",
     "client.MixinPlayerRenderer"
   ]
 }


### PR DESCRIPTION
- This event only fires if the targeted block doesn't have an action
- Stops scenarios where a bone or piece of quartz will be placed down when you open a chest
- Fixes #297