### PR TITLE
Moved Glowsilk Cocoon for GSC to Biome Modifier

### DIFF
--- a/src/main/java/org/infernalstudios/infernalexp/world/biome/netherbiomes/GlowstoneCanyonBiome.java
+++ b/src/main/java/org/infernalstudios/infernalexp/world/biome/netherbiomes/GlowstoneCanyonBiome.java
@@ -110,7 +110,6 @@ public class GlowstoneCanyonBiome extends IEBiome {
         generation.addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, NetherPlacements.GLOWSTONE_EXTRA);
         generation.addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, NetherPlacements.GLOWSTONE);
         generation.addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, OrePlacements.ORE_MAGMA);
-        generation.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, IEPlacedFeatures.ORE_GLOWSILK_COCOON);
         generation.addFeature(GenerationStep.Decoration.UNDERGROUND_DECORATION, IEPlacedFeatures.PATCH_GLOW_FIRE);
         generation.addFeature(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, IEPlacedFeatures.GLOWDUST_LAYER);
 

--- a/src/main/resources/data/infernalexp/forge/biome_modifier/add_features_glowstone_canyon.json
+++ b/src/main/resources/data/infernalexp/forge/biome_modifier/add_features_glowstone_canyon.json
@@ -1,0 +1,12 @@
+{
+  "type": "infernalexp:add_features",
+  "biome": "infernalexp:glowstone_canyon",
+  "features_at_steps": [
+    {
+      "step": "underground_ores",
+      "features": [
+        "infernalexp:ore_glowsilk_cocoon"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
According to the Forge Discord, features that are both included in a custom biome and a Vanilla biome must be added to both through BiomeModifiers in order to avoid Feature Cycles. This seems to be the only feature that is used both in a Vanilla biome and the GSC, but this is an issue to keep in mind for the future when porting.

Fixes #364 