### PR TITLE
Fix Modrinth download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </a>
   
   <a href="https://infernalstudios.org/infernalexpansion/modrinth">
-    <img alt="Modrinth Downloads" src="https://img.shields.io/badge/dynamic/json?color=red&style=for-the-badge&label=Modrinth&query=%24.downloads&suffix=%20Downloads&url=https%3A%2F%2Fapi.modrinth.com%2Fapi%2Fv1%2Fmod%2FZrpxHZN4">
+    <img alt="Modrinth Downloads" src="https://img.shields.io/modrinth/dt/ZrpxHZN4?color=red&style=for-the-badge&label=Modrinth">
   </a>
 </div>
 <br>


### PR DESCRIPTION
v1 of Modrinth's API has been deprecated since January 2022 and is scheduled to begin breaking in February, with a complete breakage being done by March. This pull request has been created as a courtesy to update it to use the dedicated shields.io badge rather than manually constructing the API request.

After merging this PR, please also update any usages on other pages, for example a CurseForge and/or Modrinth project description, and also cherry-pick/copy these changes to any other branches you might have.