### PR TITLE
Add compatibility for a couple of mods, fix some block loot table and recipe issues

### DIFF
--- a/src/main/resources/data/create/recipes/crushing/basalt_iron_ore.json
+++ b/src/main/resources/data/create/recipes/crushing/basalt_iron_ore.json
@@ -1,0 +1,33 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "infernalexp:basalt_iron_ore"
+    }
+  ],
+  "results": [
+    {
+      "item": "create:crushed_iron_ore",
+      "count": 2
+    },
+    {
+      "item": "create:crushed_iron_ore",
+      "chance": 0.25
+    },
+    {
+      "item": "create:experience_nugget",
+      "chance": 0.75
+    },
+    {
+      "item": "minecraft:basalt",
+      "chance": 0.125
+    }
+  ],
+  "processingTime": 350
+}

--- a/src/main/resources/data/create/recipes/crushing/dimstone.json
+++ b/src/main/resources/data/create/recipes/crushing/dimstone.json
@@ -1,0 +1,33 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "infernalexp:dimstone"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:glowstone_dust",
+      "count": 1
+    },
+    {
+      "item": "infernalexp:glownuggets",
+      "count": 1
+    },
+    {
+      "item": "minecraft:glowstone_dust",
+      "chance": 0.5
+    },
+    {
+      "item": "infernalexp:glownuggets",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/create/recipes/crushing/dullstone.json
+++ b/src/main/resources/data/create/recipes/crushing/dullstone.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "infernalexp:dullstone"
+    }
+  ],
+  "results": [
+    {
+      "item": "infernalexp:glownuggets",
+      "count": 3
+    },
+    {
+      "item": "infernalexp:glownuggets",
+      "chance": 0.5
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/create/recipes/crushing/glowdust_sand.json
+++ b/src/main/resources/data/create/recipes/crushing/glowdust_sand.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "infernalexp:glowdust_sand"
+    }
+  ],
+  "results": [
+    {
+      "item": "minecraft:glowstone_dust",
+      "count": 2
+    },
+    {
+      "item": "minecraft:glowstone_dust",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/create/recipes/crushing/glowdust_stone.json
+++ b/src/main/resources/data/create/recipes/crushing/glowdust_stone.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:crushing",
+  "ingredients": [
+    {
+      "item": "infernalexp:glowdust_stone"
+    }
+  ],
+  "results": [
+    {
+      "item": "infernalexp:glowdust_sand",
+      "count": 2
+    },
+    {
+      "item": "infernalexp:glowdust_sand",
+      "chance": 0.25
+    }
+  ],
+  "processingTime": 150
+}

--- a/src/main/resources/data/create/recipes/pressing/crimson_nylium_path.json
+++ b/src/main/resources/data/create/recipes/pressing/crimson_nylium_path.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+        "item": "minecraft:crimson_nylium"
+    }
+  ],
+  "results": [
+    {
+      "item": "infernalexp:crimson_nylium_path"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/pressing/soul_soil_path.json
+++ b/src/main/resources/data/create/recipes/pressing/soul_soil_path.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+        "item": "minecraft:soul_soil"
+    }
+  ],
+  "results": [
+    {
+      "item": "infernalexp:soul_soil_path"
+    }
+  ]
+}

--- a/src/main/resources/data/create/recipes/pressing/warped_nylium_path.json
+++ b/src/main/resources/data/create/recipes/pressing/warped_nylium_path.json
@@ -1,0 +1,19 @@
+{
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+        "item": "minecraft:warped_nylium"
+    }
+  ],
+  "results": [
+    {
+      "item": "infernalexp:warped_nylium_path"
+    }
+  ]
+}

--- a/src/main/resources/data/farmersdelight/recipes/cooking/blindsight_tongue_stew.json
+++ b/src/main/resources/data/farmersdelight/recipes/cooking/blindsight_tongue_stew.json
@@ -1,0 +1,31 @@
+{
+  "conditions":[
+    {
+      "type":"forge:mod_loaded",
+      "modid":"farmersdelight"
+    }
+  ],
+  "type": "farmersdelight:cooking",
+  "ingredients": [
+    {
+      "item": "infernalexp:blindsight_tongue"
+    },
+    {
+      "item": "minecraft:crimson_fungus"
+    },
+    {
+      "item": "infernalexp:luminous_fungus"
+    },
+    {
+      "item": "minecraft:warped_fungus"
+    }
+  ],
+  "result": {
+    "item": "infernalexp:blindsight_tongue_stew"
+  },
+  "container": {
+    "item": "minecraft:bowl"
+  },
+  "experience": 0.35,
+  "cookingtime": 200
+}

--- a/src/main/resources/data/forge/tags/blocks/ores/iron.json
+++ b/src/main/resources/data/forge/tags/blocks/ores/iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "infernalexp:basalt_iron_ore"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/ores/iron.json
+++ b/src/main/resources/data/forge/tags/items/ores/iron.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "infernalexp:basalt_iron_ore"
+  ]
+}

--- a/src/main/resources/data/infernalexp/loot_tables/blocks/basalt_cobbled_vertical_slab.json
+++ b/src/main/resources/data/infernalexp/loot_tables/blocks/basalt_cobbled_vertical_slab.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "infernalexp:basalt_cobbled_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/infernalexp/loot_tables/blocks/magmatic_chiseled_basalt_bricks.json
+++ b/src/main/resources/data/infernalexp/loot_tables/blocks/magmatic_chiseled_basalt_bricks.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "infernalexp:magmatic_chiseled_basalt_bricks"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/infernalexp/loot_tables/blocks/polished_basalt_slab.json
+++ b/src/main/resources/data/infernalexp/loot_tables/blocks/polished_basalt_slab.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "infernalexp:polished_basalt_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/infernalexp/loot_tables/blocks/polished_basalt_vertical_slab.json
+++ b/src/main/resources/data/infernalexp/loot_tables/blocks/polished_basalt_vertical_slab.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "infernalexp:polished_basalt_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/infernalexp/loot_tables/blocks/soul_soil_vertical_slab.json
+++ b/src/main/resources/data/infernalexp/loot_tables/blocks/soul_soil_vertical_slab.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "infernalexp:soul_soil_vertical_slab"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/infernalexp/recipes/stonecutting/basalt_bricks_vertical_slab.json
+++ b/src/main/resources/data/infernalexp/recipes/stonecutting/basalt_bricks_vertical_slab.json
@@ -3,7 +3,7 @@
   "ingredient": {
     "item": "infernalexp:basalt_bricks"
   },
-  "result": "infernalexp:basalt_bricks_vertical_slab",
+  "result": "infernalexp:basalt_brick_vertical_slab",
   "count": 2,
   "conditions": [
     {


### PR DESCRIPTION
To preface this, I've only just started testing with this mod, so the following is a few things I've caught along the way. I'll make PRs for the other production versions (1.16 if applicable, 1.19) if everything looks acceptable.

- Added missing loot tables for some blocks, fixes #412  
- Added basic Create compatibility:  
-- Dimstone can be crushed to get some glowstone dust and dullrocks
-- Dullstone can be crushed to get some dullrocks
-- Basalt iron ore can be crushed to get Create's crushed iron ore (along with some experience nuggets and basalt)
-- Shimmer stone can be crushed to get some shimmer sand, which can be crushed to get some glowstone dust
-- Warped nylium, crimson nylium and soul soil can be pressed into their respective path blocks
- Added basalt iron ore to the iron ore tag, adds automatic compatibility with Tinker's Construct and any mods that make use of Forge ore tags
- Added a cooking recipe to Fungus & Tongue Stew for Farmer's Delight compatibility
- Fixed basalt bricks vertical slab stonecutting recipe, addresses part of #398  

Please let me know if anything needs adjusting or if some mod support isn't desirable.