### PR TITLE
[1.19.2] Fix MixinItemProperties targeting the wrong class

### DIFF
--- a/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinItemProperties.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinItemProperties.java
@@ -30,7 +30,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-@Mixin(targets = "net/minecraft/client/renderer/item/ItemProperties$1")
+@Mixin(targets = "net.minecraft.client.renderer.item.ItemProperties$1")
 public class MixinItemProperties {
 
     @ModifyVariable(method = "unclampedCall", at = @At(value = "STORE", ordinal = 1 /* this ordinal is when its set to Math.random(), the second time d0 is set to something */), ordinal = 0 /* this ordinal means the first double variable */)

--- a/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinItemProperties.java
+++ b/src/main/java/org/infernalstudios/infernalexp/mixin/client/MixinItemProperties.java
@@ -30,7 +30,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import javax.annotation.Nullable;
 import java.util.Optional;
 
-@Mixin(targets = "net.minecraft.client.renderer.item.ItemProperties$static$1")
+@Mixin(targets = "net/minecraft/client/renderer/item/ItemProperties$1")
 public class MixinItemProperties {
 
     @ModifyVariable(method = "unclampedCall", at = @At(value = "STORE", ordinal = 1 /* this ordinal is when its set to Math.random(), the second time d0 is set to something */), ordinal = 0 /* this ordinal means the first double variable */)


### PR DESCRIPTION
MixinItemProperties is the class responsible for the effect clocks have being perpetually day in the Glowstone Canyons. Unfortunately, it doesn't work right now. This mixin currently targets class `net/minecraft/client/renderer/item/ItemProperties$static$1`, when it should actually be targeting `net/minecraft/client/renderer/item/ItemProperties$1`.

I'm sure that the previous name was correct in older versions of this mod, but there might have been a change with how FernFlower or ForgeFlower decompiles these classes, so the synthetic name changed. If you noticed the clocks not having the unique behavior in the Glowstone Canyons, this is why.