### PR TITLE
Fix #429

### DIFF
--- a/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
+++ b/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
@@ -57,12 +57,7 @@ public class GlowdustBlock extends Block {
 
     @Override
     public boolean isPathfindable(BlockState state, BlockGetter level, BlockPos pos, PathComputationType type) {
-        switch (type) {
-            case LAND:
-                return state.getValue(LAYERS) < HEIGHT_IMPASSABLE;
-            default:
-                return false;
-        }
+        return type == PathComputationType.LAND && state.getValue(LAYERS) < HEIGHT_IMPASSABLE;
     }
 
     @Override

--- a/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
+++ b/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
@@ -16,6 +16,22 @@
 
 package org.infernalstudios.infernalexp.blocks;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.world.level.block.state.properties.Property;
+import net.minecraft.world.level.pathfinder.PathComputationType;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import org.infernalstudios.infernalexp.init.IEBlocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.SnowLayerBlock;
@@ -23,10 +39,50 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 
 import javax.annotation.Nullable;
 
-public class GlowdustBlock extends SnowLayerBlock {
+public class GlowdustBlock extends Block {
+    private static final VoxelShape[] SHAPE_BY_LAYER = new VoxelShape[8];
+    public static final int HEIGHT_IMPASSABLE = 5;
+    public static final IntegerProperty LAYERS = BlockStateProperties.LAYERS;
+
+    static {
+        for (int i = 0; i < 8; i++) {
+            SHAPE_BY_LAYER[i] = Block.box(0.0D, 0.0D, 0.0D, 16.0D, (i + 1) * 2.0D, 16.0D);
+        }
+    }
 
     public GlowdustBlock(Properties properties) {
         super(properties);
+        this.registerDefaultState(this.getStateDefinition().any().setValue(LAYERS, 1));
+    }
+
+    @Override
+    public boolean isPathfindable(BlockState state, BlockGetter level, BlockPos pos, PathComputationType type) {
+        switch (type) {
+            case LAND:
+                return state.getValue(LAYERS) < HEIGHT_IMPASSABLE;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public VoxelShape getShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPE_BY_LAYER[state.getValue(LAYERS) - 1];
+    }
+
+    @Override
+    public VoxelShape getCollisionShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPE_BY_LAYER[state.getValue(LAYERS) - 1];
+    }
+
+    @Override
+    public VoxelShape getBlockSupportShape(BlockState state, BlockGetter level, BlockPos pos) {
+        return SHAPE_BY_LAYER[state.getValue(LAYERS) - 1];
+    }
+
+    @Override
+    public VoxelShape getVisualShape(BlockState state, BlockGetter level, BlockPos pos, CollisionContext context) {
+        return SHAPE_BY_LAYER[state.getValue(LAYERS) - 1];
     }
 
     @Override
@@ -36,12 +92,58 @@ public class GlowdustBlock extends SnowLayerBlock {
         if (blockstate.is(this)) {
             int i = blockstate.getValue(LAYERS);
             if (i < 7) {
-                return blockstate.setValue(LAYERS, Integer.valueOf(Math.min(8, i + 1)));
+                return blockstate.setValue(LAYERS, Math.min(8, i + 1));
             } else {
                 return IEBlocks.GLOWDUST_SAND.get().defaultBlockState();
             }
         } else {
             return super.getStateForPlacement(context);
         }
+    }
+
+    @Override
+    public boolean useShapeForLightOcclusion(BlockState state) {
+        return true;
+    }
+
+    @Override
+    public float getShadeBrightness(BlockState state, BlockGetter level, BlockPos pos) {
+        return state.getValue(LAYERS) == 8 ? 0.2F : 1.0F;
+    }
+
+    @Override
+    public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos) {
+        BlockState blockstate = level.getBlockState(pos.below());
+        if (blockstate.is(BlockTags.SNOW_LAYER_CANNOT_SURVIVE_ON)) {
+            return false;
+        } else if (blockstate.is(BlockTags.SNOW_LAYER_CAN_SURVIVE_ON)) {
+            return true;
+        } else {
+            return Block.isFaceFull(blockstate.getCollisionShape(level, pos.below()), Direction.UP) || blockstate.is(this) && blockstate.getValue(LAYERS) == 8;
+        }
+    }
+
+    @Override
+    public BlockState updateShape(BlockState state, Direction facing, BlockState facingState, LevelAccessor level, BlockPos pos, BlockPos facingPos) {
+        return !state.canSurvive(level, pos) ? Blocks.AIR.defaultBlockState() : super.updateShape(state, facing, facingState, level, pos, facingPos);
+    }
+
+    @Override
+    public boolean canBeReplaced(BlockState state, BlockPlaceContext context) {
+        int i = state.getValue(LAYERS);
+        if (context.getItemInHand().is(this.asItem()) && i < 8) {
+            if (context.replacingClickedOnBlock()) {
+                return context.getClickedFace() == Direction.UP;
+            } else {
+                return true;
+            }
+        } else {
+            return i == 1;
+        }
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+        builder.add(LAYERS);
     }
 }

--- a/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
+++ b/src/main/java/org/infernalstudios/infernalexp/blocks/GlowdustBlock.java
@@ -109,13 +109,7 @@ public class GlowdustBlock extends Block {
     @Override
     public boolean canSurvive(BlockState state, LevelReader level, BlockPos pos) {
         BlockState blockstate = level.getBlockState(pos.below());
-        if (blockstate.is(BlockTags.SNOW_LAYER_CANNOT_SURVIVE_ON)) {
-            return false;
-        } else if (blockstate.is(BlockTags.SNOW_LAYER_CAN_SURVIVE_ON)) {
-            return true;
-        } else {
-            return Block.isFaceFull(blockstate.getCollisionShape(level, pos.below()), Direction.UP) || blockstate.is(this) && blockstate.getValue(LAYERS) == 8;
-        }
+        return blockstate.is(BlockTags.SNOW_LAYER_CAN_SURVIVE_ON) || Block.isFaceFull(blockstate.getCollisionShape(level, pos.below()), Direction.UP) || blockstate.is(this) && blockstate.getValue(LAYERS) == 8;
     }
 
     @Override


### PR DESCRIPTION
Snow! Real Magic uses a mixin into SnowLayerBlock, which causes the issue, a simple fix by reimplementing SnowLayerBlock instead of extending it was made. Snow! Real Magic no longer mixins into the class. (Tested using commit 52e4ae6 and Snow! Real Magic 6.5.4 outside dev environment)